### PR TITLE
feat(decoder): add camera RAW preview decoding for ARW and other formats

### DIFF
--- a/app/src/main/kotlin/com/dot/gallery/GalleryApp.kt
+++ b/app/src/main/kotlin/com/dot/gallery/GalleryApp.kt
@@ -32,6 +32,7 @@ import com.dot.gallery.core.decoder.supportVideoFrame2
 import com.dot.gallery.core.decoder.supportPsdDecoder
 import com.dot.gallery.core.decoder.supportJp2Decoder
 import com.dot.gallery.core.decoder.supportTiffDecoder
+import com.dot.gallery.core.decoder.supportCameraRawDecoder
 import com.dot.gallery.core.workers.MetadataCollectionWorker
 import com.dot.gallery.core.workers.TempVaultCleanupWorker
 import com.dot.gallery.feature_node.domain.repository.MediaRepository
@@ -84,6 +85,7 @@ class GalleryApp : Application(), SingletonSketch.Factory, Configuration.Provide
             supportPsdDecoder()
             supportJp2Decoder()
             supportTiffDecoder()
+            supportCameraRawDecoder()
             supportVaultDecoder()
             supportCloudMedia()
         }

--- a/app/src/main/kotlin/com/dot/gallery/core/decoder/FullImageRegionDecoder.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/decoder/FullImageRegionDecoder.kt
@@ -7,6 +7,8 @@ package com.dot.gallery.core.decoder
 
 import android.graphics.Bitmap
 import android.util.Size as AndroidSize
+import com.dot.gallery.core.decoder.format.CameraRawImageDecoder
+import com.dot.gallery.core.decoder.format.CameraRawMime
 import com.dot.gallery.core.decoder.format.Jp2ImageDecoder
 import com.dot.gallery.core.decoder.format.PsdImageDecoder
 import com.dot.gallery.core.decoder.format.SvgImageDecoder
@@ -146,12 +148,15 @@ class FullImageRegionDecoder(
         private val supportedMimeTypes: Set<String>,
         private val decodeFull: (ByteArray) -> Bitmap?,
         private val sizeOf: (ByteArray) -> AndroidSize?,
+        private val customCheckSupport: ((String) -> Boolean?)? = null,
     ) : RegionDecoder.Factory {
 
         override suspend fun accept(subsamplingImage: SubsamplingImage): Boolean = true
 
-        override fun checkSupport(mimeType: String): Boolean? =
-            if (mimeType in supportedMimeTypes) true else null
+        override fun checkSupport(mimeType: String): Boolean? {
+            customCheckSupport?.invoke(mimeType)?.let { return it }
+            return if (mimeType in supportedMimeTypes) true else null
+        }
 
         override fun create(
             subsamplingImage: SubsamplingImage,
@@ -208,6 +213,14 @@ class FullImageRegionDecoder(
             supportedMimeTypes = setOf(SVG_MIMETYPE),
             decodeFull = { SvgImageDecoder.decode(it, SvgImageDecoder.REGION_MAX_DIM, SvgImageDecoder.REGION_MAX_DIM) },
             sizeOf = { SvgImageDecoder.renderSize(it, SvgImageDecoder.REGION_MAX_DIM, SvgImageDecoder.REGION_MAX_DIM) },
+        )
+
+        fun forCameraRaw(): Factory = Factory(
+            mimeType = "image/x-camera-raw",
+            supportedMimeTypes = emptySet(),
+            decodeFull = { CameraRawImageDecoder.decode(it, 0, 0) },
+            sizeOf = { CameraRawImageDecoder.getSize(it) },
+            customCheckSupport = { if (CameraRawMime.isCameraRaw(it)) true else null },
         )
     }
 }

--- a/app/src/main/kotlin/com/dot/gallery/core/decoder/SketchFormatDecoders.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/decoder/SketchFormatDecoders.kt
@@ -7,6 +7,8 @@ package com.dot.gallery.core.decoder
 
 import android.graphics.Bitmap
 import android.os.Build
+import com.dot.gallery.core.decoder.format.CameraRawImageDecoder
+import com.dot.gallery.core.decoder.format.CameraRawMime
 import com.dot.gallery.core.decoder.format.ImageFormatSniffer
 import com.dot.gallery.core.decoder.format.Jp2ImageDecoder
 import com.dot.gallery.core.decoder.format.PsdImageDecoder
@@ -43,6 +45,10 @@ fun ComponentRegistry.Builder.supportJp2Decoder(): ComponentRegistry.Builder = a
 
 fun ComponentRegistry.Builder.supportTiffDecoder(): ComponentRegistry.Builder = apply {
     add(SketchTiffDecoder.Factory())
+}
+
+fun ComponentRegistry.Builder.supportCameraRawDecoder(): ComponentRegistry.Builder = apply {
+    add(SketchCameraRawDecoder.Factory())
 }
 
 private fun DataSource.peekHeader(count: Int): Pair<ByteArray, Int> {
@@ -184,5 +190,44 @@ class SketchTiffDecoder(
         val bytes = dataSource.openSource().buffer().use { it.readByteArray() }
         val size = TiffImageDecoder.getSize(bytes)
         return ImageInfo(size?.width ?: 0, size?.height ?: 0, TIFF_MIMETYPE)
+    }
+}
+
+class SketchCameraRawDecoder(
+    private val requestContext: RequestContext,
+    private val dataSource: DataSource,
+    private val mimeType: String,
+) : Decoder {
+
+    class Factory : Decoder.Factory {
+        override val key: String get() = "CameraRawDecoder"
+        override val sortWeight: Int = 0
+
+        override fun create(requestContext: RequestContext, fetchResult: FetchResult): Decoder? {
+            val realMime = requestContext.request.extras?.get("realMimeType") as String?
+            val mime = realMime ?: fetchResult.mimeType
+            if (CameraRawMime.isCameraRaw(mime)) {
+                return SketchCameraRawDecoder(requestContext, fetchResult.dataSource, mime!!)
+            }
+            return null
+        }
+
+        override fun equals(other: Any?): Boolean = this === other || other is Factory
+        override fun hashCode(): Int = this@Factory::class.hashCode()
+        override fun toString(): String = key
+    }
+
+    override suspend fun decode(): ImageData {
+        val bytes = dataSource.openSource().buffer().use { it.readByteArray() }
+        val (w, h) = requestContext.targetDims()
+        val bitmap = CameraRawImageDecoder.decode(bytes, w, h, mimeType)
+            ?: throw IllegalStateException("Unable to decode camera RAW image")
+        return dataSource.toImageData(bitmap, mimeType, requestContext)
+    }
+
+    override suspend fun getImageInfo(): ImageInfo {
+        val bytes = dataSource.openSource().buffer().use { it.readByteArray() }
+        val size = CameraRawImageDecoder.getSize(bytes, mimeType)
+        return ImageInfo(size?.width ?: 0, size?.height ?: 0, mimeType)
     }
 }

--- a/app/src/main/kotlin/com/dot/gallery/core/decoder/format/CameraRawImageDecoder.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/decoder/format/CameraRawImageDecoder.kt
@@ -1,0 +1,168 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2026 IacobIacob01
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.dot.gallery.core.decoder.format
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageDecoder
+import android.os.Build
+import android.util.Log
+import android.util.Size
+import androidx.annotation.RequiresApi
+import androidx.core.graphics.scale
+import androidx.exifinterface.media.ExifInterface
+import java.io.ByteArrayInputStream
+import java.nio.ByteBuffer
+
+/**
+ * Decoder for camera RAW containers (ARW, CR2, NEF, etc.). Android cannot demosaic proprietary
+ * sensor data, so this extracts the embedded JPEG preview/thumbnail that manufacturers embed in
+ * the TIFF-based container.
+ */
+object CameraRawImageDecoder {
+
+    private const val TAG = "CameraRawImageDecoder"
+    private const val MIN_JPEG_BYTES = 256
+
+    private data class JpegSegment(val offset: Int, val length: Int)
+
+    fun getSize(bytes: ByteArray, mimeType: String? = null): Size? {
+        exifDimensions(bytes)?.let { return it }
+        val segment = selectEmbeddedJpeg(bytes, reqW = 0, reqH = 0) ?: return null
+        return jpegBounds(bytes, segment)
+    }
+
+    fun decode(bytes: ByteArray, reqW: Int, reqH: Int, mimeType: String? = null): Bitmap? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && CameraRawMime.isDng(mimeType)) {
+            decodeDng(bytes, reqW, reqH)?.let { return it }
+        }
+
+        val targetW = if (reqW > 0) reqW else 0
+        val targetH = if (reqH > 0) reqH else 0
+
+        val exifThumb = exifThumbnail(bytes)
+        if (exifThumb != null && meetsTarget(exifThumb, targetW, targetH)) {
+            return fit(exifThumb, targetW, targetH)
+        }
+
+        val embedded = selectEmbeddedJpeg(bytes, targetW, targetH)?.let { decodeJpeg(bytes, it) }
+        val bitmap = embedded ?: exifThumb ?: return null
+        return fit(bitmap, targetW, targetH)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun decodeDng(bytes: ByteArray, reqW: Int, reqH: Int): Bitmap? {
+        return try {
+            val src = ImageDecoder.createSource(ByteBuffer.wrap(bytes))
+            ImageDecoder.decodeBitmap(src) { decoder, _, _ ->
+                decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+                if (reqW > 0 && reqH > 0) decoder.setTargetSize(reqW, reqH)
+            }
+        } catch (e: Throwable) {
+            Log.w(TAG, "DNG ImageDecoder failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun exifDimensions(bytes: ByteArray): Size? {
+        return try {
+            val exif = ExifInterface(ByteArrayInputStream(bytes))
+            val w = exif.getAttributeInt(ExifInterface.TAG_IMAGE_WIDTH, 0)
+            val h = exif.getAttributeInt(ExifInterface.TAG_IMAGE_LENGTH, 0)
+            if (w > 0 && h > 0) Size(w, h) else null
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun exifThumbnail(bytes: ByteArray): Bitmap? {
+        return try {
+            val exif = ExifInterface(ByteArrayInputStream(bytes))
+            if (exif.hasThumbnail()) exif.thumbnailBitmap else null
+        } catch (e: Throwable) {
+            Log.w(TAG, "EXIF thumbnail extraction failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun selectEmbeddedJpeg(bytes: ByteArray, reqW: Int, reqH: Int): JpegSegment? {
+        val segments = findJpegSegments(bytes)
+        if (segments.isEmpty()) return null
+
+        val sorted = segments.sortedByDescending { it.length }
+        if (reqW <= 0 && reqH <= 0) return sorted.first()
+
+        val sized = sorted.mapNotNull { segment ->
+            val bounds = jpegBounds(bytes, segment) ?: return@mapNotNull null
+            segment to bounds
+        }
+        val suitable = sized
+            .filter { (_, bounds) -> bounds.width >= reqW && bounds.height >= reqH }
+            .minByOrNull { (_, bounds) -> bounds.width.toLong() * bounds.height }
+        return suitable?.first ?: sorted.first()
+    }
+
+    private fun findJpegSegments(bytes: ByteArray): List<JpegSegment> {
+        val segments = ArrayList<JpegSegment>()
+        var i = 0
+        val limit = bytes.size - 1
+        while (i < limit) {
+            if (bytes[i] == 0xFF.toByte() && bytes[i + 1] == 0xD8.toByte()) {
+                var j = i + 2
+                var found = false
+                while (j < limit) {
+                    if (bytes[j] == 0xFF.toByte() && bytes[j + 1] == 0xD9.toByte()) {
+                        val end = j + 2
+                        val length = end - i
+                        if (length >= MIN_JPEG_BYTES) {
+                            segments.add(JpegSegment(i, length))
+                        }
+                        i = end
+                        found = true
+                        break
+                    }
+                    j++
+                }
+                if (!found) i++
+            } else {
+                i++
+            }
+        }
+        return segments
+    }
+
+    private fun jpegBounds(bytes: ByteArray, segment: JpegSegment): Size? {
+        if (segment.offset < 0 || segment.offset + segment.length > bytes.size) return null
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, segment.offset, segment.length, options)
+        return if (options.outWidth > 0 && options.outHeight > 0) {
+            Size(options.outWidth, options.outHeight)
+        } else {
+            null
+        }
+    }
+
+    private fun decodeJpeg(bytes: ByteArray, segment: JpegSegment): Bitmap? {
+        if (segment.offset < 0 || segment.offset + segment.length > bytes.size) return null
+        return BitmapFactory.decodeByteArray(bytes, segment.offset, segment.length)
+    }
+
+    private fun meetsTarget(bitmap: Bitmap, reqW: Int, reqH: Int): Boolean {
+        if (reqW <= 0 && reqH <= 0) return true
+        return bitmap.width >= reqW && bitmap.height >= reqH
+    }
+
+    private fun fit(src: Bitmap, maxW: Int, maxH: Int): Bitmap {
+        if (maxW <= 0 || maxH <= 0) return src
+        if (src.width <= maxW && src.height <= maxH) return src
+        val scale = minOf(maxW.toFloat() / src.width, maxH.toFloat() / src.height)
+        val tw = (src.width * scale).toInt().coerceAtLeast(1)
+        val th = (src.height * scale).toInt().coerceAtLeast(1)
+        val scaled = src.scale(tw, th)
+        if (scaled != src) src.recycle()
+        return scaled
+    }
+}

--- a/app/src/main/kotlin/com/dot/gallery/core/decoder/format/CameraRawImageDecoder.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/decoder/format/CameraRawImageDecoder.kt
@@ -30,9 +30,10 @@ object CameraRawImageDecoder {
     private data class JpegSegment(val offset: Int, val length: Int)
 
     fun getSize(bytes: ByteArray, mimeType: String? = null): Size? {
-        exifDimensions(bytes)?.let { return it }
-        val segment = selectEmbeddedJpeg(bytes, reqW = 0, reqH = 0) ?: return null
-        return jpegBounds(bytes, segment)
+        selectEmbeddedJpeg(bytes, reqW = 0, reqH = 0)?.let { segment ->
+            jpegBounds(bytes, segment)?.let { return it }
+        }
+        return exifDimensions(bytes)
     }
 
     fun decode(bytes: ByteArray, reqW: Int, reqH: Int, mimeType: String? = null): Bitmap? {
@@ -42,14 +43,15 @@ object CameraRawImageDecoder {
 
         val targetW = if (reqW > 0) reqW else 0
         val targetH = if (reqH > 0) reqH else 0
+        val wantsThumbnail = targetW > 0 && targetH > 0
 
-        val exifThumb = exifThumbnail(bytes)
+        val exifThumb = if (wantsThumbnail) exifThumbnail(bytes) else null
         if (exifThumb != null && meetsTarget(exifThumb, targetW, targetH)) {
             return fit(exifThumb, targetW, targetH)
         }
 
         val embedded = selectEmbeddedJpeg(bytes, targetW, targetH)?.let { decodeJpeg(bytes, it) }
-        val bitmap = embedded ?: exifThumb ?: return null
+        val bitmap = embedded ?: exifThumbnail(bytes) ?: return null
         return fit(bitmap, targetW, targetH)
     }
 

--- a/app/src/main/kotlin/com/dot/gallery/core/decoder/format/CameraRawMime.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/decoder/format/CameraRawMime.kt
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2026 IacobIacob01
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.dot.gallery.core.decoder.format
+
+/**
+ * MIME registry for camera RAW formats. Most vendor RAW files are reported as `image/x-*` or
+ * `image/vnd.*` by MediaStore, but a few non-RAW formats share those prefixes.
+ */
+object CameraRawMime {
+
+    private val EXCLUDED_MIME_TYPES = setOf(
+        "image/vnd.adobe.photoshop",
+        "image/vnd.ms-photo",
+        "image/vnd.wap.wbmp",
+        "image/x-photoshop",
+        "image/photoshop",
+    )
+
+    fun isCameraRaw(mime: String?): Boolean {
+        if (mime.isNullOrEmpty()) return false
+        val lower = mime.lowercase().substringBefore(';').trim()
+        if (lower in EXCLUDED_MIME_TYPES) return false
+        return lower.startsWith("image/x-") || lower.startsWith("image/vnd.")
+    }
+
+    fun isDng(mime: String?): Boolean = mime?.lowercase()?.contains("dng") == true
+}

--- a/app/src/main/kotlin/com/dot/gallery/core/decoder/glide/CameraRawMimeInputStreamDecoder.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/decoder/glide/CameraRawMimeInputStreamDecoder.kt
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2026 IacobIacob01
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.dot.gallery.core.decoder.glide
+
+import android.graphics.Bitmap
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.ResourceDecoder
+import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
+import com.bumptech.glide.load.resource.bitmap.BitmapResource
+import com.dot.gallery.core.decoder.format.CameraRawImageDecoder
+import com.dot.gallery.core.decoder.format.CameraRawMime
+
+/**
+ * Camera RAW decoder for the MimeInputStream (content Uri) path. Extracts the embedded JPEG
+ * preview/thumbnail from TIFF-based RAW containers.
+ */
+class CameraRawMimeInputStreamDecoder(
+    private val bitmapPool: BitmapPool
+) : ResourceDecoder<MimeInputStream, Bitmap> {
+
+    override fun handles(source: MimeInputStream, options: Options): Boolean =
+        CameraRawMime.isCameraRaw(source.mimeType)
+
+    override fun decode(
+        source: MimeInputStream,
+        width: Int,
+        height: Int,
+        options: Options
+    ): Resource<Bitmap>? {
+        val data = source.inputStream.readBytes()
+        val bmp = CameraRawImageDecoder.decode(data, width, height, source.mimeType) ?: return null
+        return BitmapResource.obtain(bmp, bitmapPool)
+    }
+}

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/media/ZoomablePagerImage.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/media/ZoomablePagerImage.kt
@@ -48,6 +48,7 @@ import com.dot.gallery.feature_node.domain.util.isEncrypted
 import com.dot.gallery.feature_node.domain.util.isJp2
 import com.dot.gallery.feature_node.domain.util.isJxl
 import com.dot.gallery.feature_node.domain.util.isPsd
+import com.dot.gallery.feature_node.domain.util.isRaw
 import com.dot.gallery.feature_node.domain.util.isSvg
 import com.dot.gallery.feature_node.domain.util.isTiff
 import com.dot.gallery.feature_node.presentation.mediaview.rememberedDerivedState
@@ -132,7 +133,7 @@ fun <T : Media> ZoomablePagerImage(
     val isAnimated = remember(media) {
         media.isApng || media.isJxl || (media.isAvif && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
     }
-    // Region decoder for formats Android's BitmapRegionDecoder can't subsample (PSD/JP2/TIFF/SVG).
+    // Region decoder for formats Android's BitmapRegionDecoder can't subsample (PSD/JP2/TIFF/SVG/RAW).
     // Without this they only show the screen-resolution base painter and look blurry when zoomed.
     val customRegionFactory = remember(media) {
         when {
@@ -140,6 +141,7 @@ fun <T : Media> ZoomablePagerImage(
             media.isJp2 -> FullImageRegionDecoder.forJp2()
             media.isTiff -> FullImageRegionDecoder.forTiff()
             media.isSvg -> FullImageRegionDecoder.forSvg()
+            media.isRaw -> FullImageRegionDecoder.forCameraRaw()
             else -> null
         }
     }

--- a/app/src/main/kotlin/com/dot/gallery/injection/GlideModule.kt
+++ b/app/src/main/kotlin/com/dot/gallery/injection/GlideModule.kt
@@ -34,6 +34,7 @@ import com.dot.gallery.core.decoder.glide.MimeInputStreamModelLoader
 import com.dot.gallery.core.decoder.glide.PsdBitmapDecoder
 import com.dot.gallery.core.decoder.glide.Jp2BitmapDecoder
 import com.dot.gallery.core.decoder.glide.SvgBitmapDecoder
+import com.dot.gallery.core.decoder.glide.CameraRawMimeInputStreamDecoder
 import com.dot.gallery.core.decoder.glide.TiffMimeInputStreamDecoder
 import com.dot.gallery.core.decoder.glide.StreamingEncryptedVideoFrameDecoder
 import java.io.File
@@ -97,6 +98,12 @@ class GlideModule: AppGlideModule() {
             MimeInputStream::class.java,
             Bitmap::class.java,
             TiffMimeInputStreamDecoder(pool)
+        )
+        // Camera RAW via content Uri MIME (image/x-sony-arw, image/x-canon-cr2, etc.)
+        registry.prepend(
+            MimeInputStream::class.java,
+            Bitmap::class.java,
+            CameraRawMimeInputStreamDecoder(pool)
         )
         // Formats Android can't decode natively, detected by magic bytes (MIME is unreliable):
         // PSD, JPEG 2000, and SVG (rasterized). Registered on the InputStream path.


### PR DESCRIPTION
## Summary

- Add a camera RAW decoder that extracts embedded JPEG previews from TIFF-based RAW containers (ARW, CR2, NEF, etc.)
- Wire the decoder into timeline thumbnails and media viewer.

## Approach

- `CameraRawImageDecoder` scans for embedded JPEG segments, falls back to EXIF thumbnail; DNG attempts `ImageDecoder` first
- `CameraRawMime` MIME detection for `image/x-*` and `image/vnd.*`, with exclusions for PSD and other non-RAW vendor types.
- Registered on both `CameraRawMimeInputStreamDecoder` and `SketchCameraRawDecoder` pipelines
- `FullImageRegionDecoder.forCameraRaw()` added for RAW zooming

## Limitations/Considerations

- **Preview only** displays the manufacturer-embedded JPEG, not a full RAW.
- **MIME-dependent** relies on MediaStore reporting correct vendor MIME types.
- **Performance** first load of large RAW files (40MB+) reads the full file to locate embedded previews - subsequent loads are cached by glide/sketch.

## Impact on non-RAW users

No meaningful impact. Non-RAW images only hit a single `handles()` MIME check and are rejected immediately. No file scanning or decoding occurs.
