### PR TITLE
fix: Disable AI model deletion in offline builds

### DIFF
--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/settings/subsettings/AIModelsManagerScreen.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/settings/subsettings/AIModelsManagerScreen.kt
@@ -1,6 +1,8 @@
 package com.dot.gallery.feature_node.presentation.settings.subsettings
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.text.format.Formatter
 import androidx.core.net.toUri
 import androidx.compose.foundation.background
@@ -45,6 +47,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.BlendMode
@@ -250,14 +253,20 @@ private fun ModelGroupSection(
     val info by viewModel.downloadInfo(group).collectAsStateWithLifecycle()
     val error by viewModel.errorMessage(group).collectAsStateWithLifecycle()
     var showDeleteDialog by remember { mutableStateOf(false) }
+    // Offline flavor strips android.permission.INTERNET at build time; use that as the signal.
+    val isOfflineBuild = remember(context) {
+        context.checkSelfPermission(Manifest.permission.INTERNET) != PackageManager.PERMISSION_GRANTED
+    }
 
     val actionTitle: String
     val actionSummary: String
     val actionClick: () -> Unit
+    var actionEnabled = true
     when (status) {
         ModelStatus.READY -> {
             val sizeStr = Formatter.formatFileSize(context, viewModel.installedSize(group))
             actionTitle = stringResource(R.string.ai_models_delete)
+            actionEnabled = !isOfflineBuild
             actionSummary = readySummary + "\n" + stringResource(R.string.ai_models_size, sizeStr)
             actionClick = { showDeleteDialog = true }
         }
@@ -327,7 +336,8 @@ private fun ModelGroupSection(
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(16.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .clickable { actionClick() }
+                .clickable(enabled = actionEnabled) { actionClick() }
+                .alpha(if (actionEnabled) 1f else 0.5f)
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {


### PR DESCRIPTION
## Summary
Offline builds strip `android.permission.INTERNET`, so once an AI model group is deleted from the on-device cache there is no way to fetch it again from within the app. The "Delete" action on each model group card in **Settings → Smart Features → AI Models Manager** was still fully live in these builds, letting users get into a broken state that could only be recovered by exporting settings, uninstalling, reinstalling, and restoring.

This PR disables that action in offline builds while leaving everything else about the screen unchanged.

## Issue
Reference: #1118
```
The user can still delete the ML models in the "offline" only builds as the options to delete them are still available.
Since there is no network permission granted to the app, it is almost impossible to redownload the models.

As a workaround, one can perform these steps to restore the models:

- Backup and export settings
- Uninstall ReFra
- Reinstall ReFra and proceed with the wizard
- Restore settings

While a workaround is available, a better solution is to add a condition to the UI to either fully disable or remove the option to "delete" the ML models.
```
## Fix

Scope: single file — AIModelsManagerScreen.kt.

- Detect an offline build at runtime by checking whether `Manifest.permission.INTERNET` is granted. Offline flavor builds strip that permission in `manifestConfig { stripPermissions.set(...) }` (see build.gradle.kts), so a missing declaration is a reliable signal without adding a new `BuildConfig` field.

  ```kotlin
  val isOfflineBuild = remember(context) {
      context.checkSelfPermission(Manifest.permission.INTERNET) != PackageManager.PERMISSION_GRANTED
  }
  ```

- Introduced an `actionEnabled` flag alongside the existing `actionTitle` / `actionSummary` / `actionClick`. It defaults to `true` and is only flipped in the `ModelStatus.READY` branch:

  ```kotlin
  actionEnabled = !isOfflineBuild
  ```

- Applied that flag to the action card modifier so the click is fully gated at the `Modifier` layer and the card is visibly dimmed:

  ```kotlin
  .clickable(enabled = actionEnabled) { actionClick() }
  .alpha(if (actionEnabled) 1f else 0.5f)
  ```

Result:
- **Offline build + READY** → Delete card is dimmed at 50 % alpha, no ripple, no click reaction, no dialog. The delete confirmation dialog is never reachable.
- **Any other state, or non-offline build** → unchanged behaviour (Download / Cancel / Delete confirmation dialog).

## Why this file only
All other layers already handle offline correctly:
- `SmartFeaturesViewModel.downloadModels(...)` already short-circuits on `!modelManager.hasInternetPermission`.
- `ModelDownloadWorker` requires `NetworkType.CONNECTED`, so it can't run in an offline build anyway.
- `ModelManager.deleteModels(...)` is a legitimate operation in non-offline builds and shouldn't change.

The only surface actively driving users into the broken state was the UI action, so the fix is contained to the UI.

## Test plan
- [x] Offline build, all groups in `READY` state → the Delete card is visibly dimmed, tapping does nothing, no dialog appears. Other sections (Source link, per-file SHA-256 details) still interact normally.
- [x] Non-offline build (`WithML` or `NoML` with INTERNET) → Delete card unchanged, tapping opens the confirm dialog, `viewModel.deleteModels(group)` still fires on confirm.
- [x] `NOT_INSTALLED` / `DOWNLOADING` / `COPYING` / `ERROR` states → identical to previous behaviour in both build types.
- [x] `./gradlew :app:compile*` — no new diagnostics on the touched file.

## Related
Closes #1118