### PR TITLE
fix: allow copying media out of restricted folders

### DIFF
--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/CopyMediaSheet.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/CopyMediaSheet.kt
@@ -64,8 +64,6 @@ import com.dot.gallery.core.presentation.components.SecurityInfoSheet
 import com.dot.gallery.feature_node.domain.model.Album
 import com.dot.gallery.feature_node.domain.model.AlbumState
 import com.dot.gallery.feature_node.domain.model.Media
-import com.dot.gallery.feature_node.domain.util.isCloud
-import com.dot.gallery.feature_node.domain.util.mediaStoreVolumeName
 import com.dot.gallery.feature_node.presentation.albums.components.AlbumComponent
 import com.dot.gallery.feature_node.presentation.mediaview.rememberedDerivedState
 import com.dot.gallery.feature_node.presentation.util.AppBottomSheetState
@@ -101,16 +99,11 @@ fun <T: Media> CopyMediaSheet(
     var pendingLockedAlbumPath by remember { mutableStateOf<String?>(null) }
     var searchQuery by remember { mutableStateOf("") }
     val mutex = Mutex()
-    val sources = mediaList.filter { !it.isCloud }.map {
-        AlbumDestinationSource(it.mediaStoreVolumeName, it.relativePath)
-    }
 
     fun Album.isCopyDestinationEnabled(): Boolean = absolutePath.isNotBlank() &&
-        isAlbumDestinationEnabled(
+        isAlbumCopyDestinationEnabled(
             hasFullMediaAccess = hasFullMediaAccess,
-            albumVolume = volume,
             albumRelativePath = relativePath,
-            sources = sources,
             isCloudAlbum = uri.scheme == "cloud" || relativePath.startsWith("cloud/"),
         )
 

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
@@ -461,6 +461,21 @@ internal fun isAlbumDestinationEnabled(
     }
 }
 
+/**
+ * A copy only reads the source through MediaStore and inserts a brand new file at the
+ * destination, so restricted sources (another app's `Android/media/<package>` folder, or a
+ * different storage volume) do not need write access. Only the destination has to be writable.
+ */
+internal fun isAlbumCopyDestinationEnabled(
+    hasFullMediaAccess: Boolean,
+    albumRelativePath: String,
+    isCloudAlbum: Boolean = false,
+): Boolean {
+    if (isCloudAlbum) return false
+    if (hasFullMediaAccess) return true
+    return !albumRelativePath.isAndroidMediaPath()
+}
+
 internal fun isAlbumMoveDestinationEnabled(
     hasFullMediaAccess: Boolean,
     albumVolume: String,

--- a/app/src/test/java/com/dot/gallery/AlbumDestinationPolicyTest.kt
+++ b/app/src/test/java/com/dot/gallery/AlbumDestinationPolicyTest.kt
@@ -94,6 +94,56 @@ class AlbumDestinationPolicyTest {
     }
 
     @Test
+    fun copyFromRestrictedSourceStaysEnabledForWritableAlbum() {
+        // Copying a WhatsApp image (Android/media/com.whatsapp/...) into an existing album only
+        // reads the source and inserts a new file at the destination.
+        val restrictedSource = listOf(
+            AlbumDestinationSource(
+                "external_primary",
+                "Android/media/com.whatsapp/WhatsApp/Media/WhatsApp Images/",
+            ),
+        )
+
+        assertTrue(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = false,
+                albumRelativePath = "Pictures/Target/",
+            )
+        )
+        assertFalse(
+            isAlbumMoveDestinationEnabled(
+                false,
+                "external_primary",
+                "Pictures/Target/",
+                restrictedSource,
+            )
+        )
+    }
+
+    @Test
+    fun copyToRestrictedOrCloudAlbumStaysDisabled() {
+        assertFalse(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = false,
+                albumRelativePath = "Android/media/example.app/Pictures/",
+            )
+        )
+        assertFalse(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = true,
+                albumRelativePath = "cloud/IMMICH/Album",
+                isCloudAlbum = true,
+            )
+        )
+        assertTrue(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = true,
+                albumRelativePath = "Android/media/example.app/Pictures/",
+            )
+        )
+    }
+
+    @Test
     fun moveDisablesExactSourceFolderButAllowsDifferentSameNamedFolder() {
         val sources = listOf(AlbumDestinationSource("external_primary", "DCIM/Camera/"))
 


### PR DESCRIPTION
Fixes #1144

### Problem

With the copy sheet, every existing album is greyed out as soon as the selection contains media stored in another app's `Android/media/<package>/` folder — in practice, any image received through WhatsApp. Only *New album* stays selectable, and copying to a new album works, which makes the behaviour look arbitrary from the user's point of view.

### Cause

`isAlbumDestinationEnabled()` is shared between the move and the copy sheets and rejects a destination whenever a *source* is restricted:

```kotlin
return !albumRelativePath.isAndroidMediaPath() && sources.all {
    it.volume == albumVolume && !it.relativePath.isAndroidMediaPath()
}
```

That is right for a move, which has to delete the original. A copy never touches the source: `MediaCopyWorker` opens an input stream on the source URI and `insert()`s a new file at the destination, so only the destination needs to be writable.

### Fix

Add `isAlbumCopyDestinationEnabled()` for the copy path — cloud destinations and `Android/media` destinations remain disabled without full media access, the source is no longer taken into account — and leave `isAlbumMoveDestinationEnabled()` untouched.

### Tests

`AlbumDestinationPolicyTest` gains two cases: copying from a restricted (`Android/media/com.whatsapp/…`) source into a normal album is enabled while moving from it is still disabled, and copying to a restricted or cloud destination stays disabled.

```
./gradlew :app:testArm64-v8aNoMLDebugUnitTest --tests "com.dot.gallery.feature_node.presentation.exif.AlbumDestinationPolicyTest"   # 12/12
./gradlew :app:assembleArm64-v8aNoMLDebug
```

### Device verification

OnePlus 5T, LineageOS 22 (Android 15), without "All files access" or "Media management":

- same debug build **without** the patch: every existing album greyed out when copying a WhatsApp image (bug reproduced);
- **with** the patch: the album is selectable and the copy completes.

### Note

Moving media out of `Android/media/<package>` stays disabled, which is accurate today. A possible follow-up — deliberately not in this PR — would be to implement that move as copy + `MediaStore.createDeleteRequest()` on the source, letting the user consent to the deletion through the system dialog. Happy to look into it separately if you are interested.
