### PR TITLE
feat: move media out of restricted folders, and keep the source date on copies

### DIFF
--- a/app/src/androidTest/java/com/dot/gallery/core/util/ext/MediaTimestampTest.kt
+++ b/app/src/androidTest/java/com/dot/gallery/core/util/ext/MediaTimestampTest.kt
@@ -1,0 +1,73 @@
+package com.dot.gallery.core.util.ext
+
+import android.content.ContentValues
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MediaTimestampTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val resolver = context.contentResolver
+    private val sourceDateModified = 1600000000L // 2020-09-13
+
+    @Test
+    fun copiedMediaKeepsTheTimestampOfItsSource() = runBlocking {
+        val uri = writeImage()
+        try {
+            // MediaProvider hands out the time of the write, whatever the app asked for.
+            assertTrue(dateModifiedOf(uri) > sourceDateModified)
+
+            assertTrue(
+                context.restoreMediaTimestamp(uri, "image/jpeg", sourceDateModified)
+            )
+            assertEquals(sourceDateModified, dateModifiedOf(uri))
+        } finally {
+            resolver.delete(uri, null, null)
+        }
+    }
+
+    @Test
+    fun unknownSourceTimestampLeavesTheCopyAlone() = runBlocking {
+        val uri = writeImage()
+        try {
+            val written = dateModifiedOf(uri)
+            assertTrue(!context.restoreMediaTimestamp(uri, "image/jpeg", 0L))
+            assertEquals(written, dateModifiedOf(uri))
+        } finally {
+            resolver.delete(uri, null, null)
+        }
+    }
+
+    private fun writeImage(): Uri {
+        val uri = resolver.insert(
+            MediaStore.Images.Media.getContentUri("external_primary"),
+            ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, "timestamp-${System.nanoTime()}.jpg")
+                put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+                put(MediaStore.MediaColumns.RELATIVE_PATH, "Pictures/ReFraTimestampTest/")
+                put(MediaStore.MediaColumns.IS_PENDING, 1)
+                put(MediaStore.MediaColumns.DATE_MODIFIED, sourceDateModified)
+            }
+        )!!
+        resolver.openOutputStream(uri)!!.use {
+            it.write(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xD9.toByte()))
+        }
+        resolver.update(
+            uri,
+            ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
+            null,
+            null
+        )
+        return uri
+    }
+
+    private fun dateModifiedOf(uri: Uri): Long = resolver.mediaDateModified(uri)
+}

--- a/app/src/main/kotlin/com/dot/gallery/core/MediaHandler.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/MediaHandler.kt
@@ -47,6 +47,14 @@ interface MediaHandler {
 
     suspend fun <T: Media> moveMedia(media: T, newPath: String): Boolean
 
+    suspend fun <T: Media> copyMediaForMove(
+        mediaList: List<T>,
+        newPath: String,
+        onProgress: suspend (Float) -> Unit = {}
+    ): List<Uri>
+
+    suspend fun discardMediaCopies(uris: List<Uri>)
+
     suspend fun probeMetadataSanitization(media: Media): SanitizationCapability
 
     suspend fun sanitizeMediaMetadata(

--- a/app/src/main/kotlin/com/dot/gallery/core/MediaHandlerImpl.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/MediaHandlerImpl.kt
@@ -181,6 +181,15 @@ class MediaHandlerImpl @Inject constructor(
         newPath: String
     ): Boolean = repository.moveMedia(media, newPath)
 
+    override suspend fun <T : Media> copyMediaForMove(
+        mediaList: List<T>,
+        newPath: String,
+        onProgress: suspend (Float) -> Unit
+    ): List<Uri> = repository.copyMediaForMove(mediaList, newPath, onProgress)
+
+    override suspend fun discardMediaCopies(uris: List<Uri>) =
+        repository.discardMediaCopies(uris)
+
     override suspend fun probeMetadataSanitization(
         media: Media
     ): SanitizationCapability = repository.probeMetadataSanitization(media)

--- a/app/src/main/kotlin/com/dot/gallery/core/util/ext/ContentResolverExt.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/util/ext/ContentResolverExt.kt
@@ -33,9 +33,11 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -43,6 +45,53 @@ import java.io.IOException
 import java.io.OutputStream
 
 @RequiresApi(Build.VERSION_CODES.R)
+/** DATE_MODIFIED of [uri] in seconds, or 0 when it cannot be read. */
+fun ContentResolver.mediaDateModified(uri: Uri): Long {
+    runCatching {
+        query(uri, arrayOf(MediaStore.MediaColumns.DATE_MODIFIED), null, null, null)?.use {
+            if (it.moveToFirst() && !it.isNull(0)) return it.getLong(0)
+        }
+    }.onFailure { printWarning("Failed to read the date of $uri: ${it.message}") }
+    return 0L
+}
+
+/**
+ * Gives a freshly written copy the timestamp of the media it was copied from. MediaProvider
+ * ignores DATE_MODIFIED/DATE_TAKEN coming from an app and recomputes them from the file, so the
+ * timestamp has to be set on the file itself and picked up by a rescan - otherwise every copy
+ * jumps to the top of its album, ordered as if it had just been taken.
+ */
+suspend fun Context.restoreMediaTimestamp(
+    uri: Uri,
+    mimeType: String?,
+    dateModifiedSeconds: Long
+): Boolean {
+    if (dateModifiedSeconds <= 0L) return false
+    val path = runCatching {
+        contentResolver.query(
+            uri,
+            arrayOf(MediaStore.MediaColumns.DATA),
+            null,
+            null,
+            null
+        )?.use { if (it.moveToFirst()) it.getString(0) else null }
+    }.getOrNull() ?: return false
+    if (!File(path).setLastModified(dateModifiedSeconds * 1000)) return false
+    return withTimeoutOrNull(SCAN_TIMEOUT_MS) {
+        suspendCancellableCoroutine { continuation ->
+            MediaScannerConnection.scanFile(
+                this@restoreMediaTimestamp,
+                arrayOf(path),
+                arrayOf(mimeType)
+            ) { _, _ ->
+                if (continuation.isActive) continuation.resume(true) {  _, _, _ -> }
+            }
+        }
+    } ?: false
+}
+
+private const val SCAN_TIMEOUT_MS = 10_000L
+
 fun ContentResolver.querySteppedFlow(
     uri: Uri,
     projection: Array<String>? = null,

--- a/app/src/main/kotlin/com/dot/gallery/core/workers/MediaCopyWorker.kt
+++ b/app/src/main/kotlin/com/dot/gallery/core/workers/MediaCopyWorker.kt
@@ -17,6 +17,8 @@ import com.dot.gallery.cloud.core.ProviderType
 import com.dot.gallery.cloud.core.capabilities.RemoteMediaProvider
 import com.dot.gallery.cloud.image.CloudFetcherRegistryHolder
 import com.dot.gallery.core.util.ProgressThrottler
+import com.dot.gallery.core.util.ext.mediaDateModified
+import com.dot.gallery.core.util.ext.restoreMediaTimestamp
 import com.dot.gallery.feature_node.domain.model.Media
 import com.dot.gallery.feature_node.domain.util.getUri
 import com.dot.gallery.feature_node.domain.util.resolveMediaStoreVolume
@@ -163,6 +165,7 @@ class MediaCopyWorker @AssistedInject constructor(
                     src.lastPathSegment ?: "media"
                 }
                 val isVideo = mediaType.startsWith("video")
+                val sourceDateModified = if (isCloudUri) 0L else cr.mediaDateModified(src)
                 val targetUri = cr.insert(
                     if (isVideo) MediaStore.Video.Media.getContentUri(volumeName)
                     else MediaStore.Images.Media.getContentUri(volumeName),
@@ -196,12 +199,12 @@ class MediaCopyWorker @AssistedInject constructor(
 
                 val updateValues = ContentValues().apply {
                     put(MediaStore.MediaColumns.IS_PENDING, 0)
-                    put(
-                        MediaStore.MediaColumns.DATE_MODIFIED,
-                        System.currentTimeMillis() / 1000
-                    )
                 }
-                return@withContext cr.update(targetUri, updateValues, null, null) > 0
+                val published = cr.update(targetUri, updateValues, null, null) > 0
+                // Keep the copy where the source sits in the timeline instead of sending it to
+                // the top of the destination album with today's date.
+                appContext.restoreMediaTimestamp(targetUri, mediaType, sourceDateModified)
+                return@withContext published
             } catch (e: IOException) {
                 if (e.message?.contains("ENOSPC") == true) return@withContext false
                 return@withContext false

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
@@ -111,7 +111,9 @@ import com.dot.gallery.feature_node.presentation.util.printError
 import com.dot.gallery.feature_node.presentation.util.mediaStoreVersion
 import com.dot.gallery.feature_node.presentation.util.printInfo
 import com.dot.gallery.feature_node.presentation.util.printWarning
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -612,16 +614,22 @@ class MediaRepositoryImpl(
     ): List<Uri> = withContext(Dispatchers.IO) {
         val (destVolume, destRelPath) = resolveMediaStoreVolume(newPath)
         val copies = mutableListOf<Uri>()
-        mediaList.forEachIndexed { index, media ->
-            val copiedUri = copyMediaTo(media, destVolume, destRelPath)
-            if (copiedUri == null) {
-                // Never leave half a move behind: the originals are still untouched at this
-                // point, so drop the copies we own and report the failure.
-                discardMediaCopies(copies)
-                return@withContext emptyList()
+        try {
+            mediaList.forEachIndexed { index, media ->
+                val copiedUri = copyMediaTo(media, destVolume, destRelPath)
+                if (copiedUri == null) {
+                    // Never leave half a move behind: the originals are still untouched at this
+                    // point, so drop the copies we own and report the failure.
+                    discardMediaCopies(copies)
+                    return@withContext emptyList()
+                }
+                copies += copiedUri
+                onProgress((index + 1).toFloat() / mediaList.size)
             }
-            copies += copiedUri
-            onProgress((index + 1).toFloat() / mediaList.size)
+        } catch (e: CancellationException) {
+            // Leaving the sheet mid-copy cancels this scope; clean up before giving up.
+            withContext(NonCancellable) { discardMediaCopies(copies) }
+            throw e
         }
         copies
     }

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
@@ -34,6 +34,8 @@ import com.dot.gallery.core.metadata.SanitizationCapability
 import com.dot.gallery.core.metadata.SanitizationResult
 import com.dot.gallery.core.util.MediaStoreBuckets
 import com.dot.gallery.core.util.ext.mapAsResource
+import com.dot.gallery.core.util.ext.mediaDateModified
+import com.dot.gallery.core.util.ext.restoreMediaTimestamp
 import com.dot.gallery.core.util.ext.overrideImageEncoded
 import com.dot.gallery.core.util.ext.renameMedia
 import com.dot.gallery.core.util.ext.saveImage
@@ -567,6 +569,8 @@ class MediaRepositoryImpl(
             val mediaType = cr.getType(srcUri) ?: return@withContext null
             val isVideo = mediaType.startsWith("video")
 
+            val sourceDateModified = cr.mediaDateModified(srcUri)
+
             val targetUri = cr.insert(
                 if (isVideo) MediaStore.Video.Media.getContentUri(destVolume)
                 else MediaStore.Images.Media.getContentUri(destVolume),
@@ -592,6 +596,8 @@ class MediaRepositoryImpl(
                 ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
                 null, null
             )
+            // The copy belongs where the source was in the timeline, not at today's date.
+            context.restoreMediaTimestamp(targetUri, media.mimeType, sourceDateModified)
             targetUri
         } catch (e: Exception) {
             printWarning("Copy to $destRelPath failed: ${e.message}")

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
@@ -540,10 +540,31 @@ class MediaRepositoryImpl(
         destVolume: String,
         destRelPath: String
     ): Boolean = withContext(Dispatchers.IO) {
-        val cr = context.contentResolver
+        val copiedUri = copyMediaTo(media, destVolume, destRelPath)
+            ?: return@withContext false
+        try {
+            contentResolver.delete(media.getUri(), null, null)
+            true
+        } catch (e: Exception) {
+            printWarning("Cross-volume move failed: ${e.message}")
+            contentResolver.delete(copiedUri, null, null)
+            false
+        }
+    }
+
+    /**
+     * Writes a copy of [media] into [destRelPath] on [destVolume] and returns its uri, or null
+     * when the copy could not be completed. Nothing is written on failure.
+     */
+    private suspend fun <T : Media> copyMediaTo(
+        media: T,
+        destVolume: String,
+        destRelPath: String
+    ): Uri? = withContext(Dispatchers.IO) {
+        val cr = contentResolver
         try {
             val srcUri = media.getUri()
-            val mediaType = cr.getType(srcUri) ?: return@withContext false
+            val mediaType = cr.getType(srcUri) ?: return@withContext null
             val isVideo = mediaType.startsWith("video")
 
             val targetUri = cr.insert(
@@ -555,7 +576,7 @@ class MediaRepositoryImpl(
                     put(MediaStore.MediaColumns.RELATIVE_PATH, destRelPath)
                     put(MediaStore.MediaColumns.IS_PENDING, 1)
                 }
-            ) ?: return@withContext false
+            ) ?: return@withContext null
 
             cr.openInputStream(srcUri)?.use { input ->
                 cr.openOutputStream(targetUri)?.use { output ->
@@ -563,23 +584,46 @@ class MediaRepositoryImpl(
                 }
             } ?: run {
                 cr.delete(targetUri, null, null)
-                return@withContext false
+                return@withContext null
             }
 
             cr.update(
                 targetUri,
-                ContentValues().apply {
-                    put(MediaStore.MediaColumns.IS_PENDING, 0)
-                    put(MediaStore.MediaColumns.DATE_MODIFIED, System.currentTimeMillis() / 1000)
-                },
+                ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
                 null, null
             )
-
-            cr.delete(srcUri, null, null)
-            true
+            targetUri
         } catch (e: Exception) {
-            printWarning("Cross-volume move failed: ${e.message}")
-            false
+            printWarning("Copy to $destRelPath failed: ${e.message}")
+            null
+        }
+    }
+
+    override suspend fun <T : Media> copyMediaForMove(
+        mediaList: List<T>,
+        newPath: String,
+        onProgress: suspend (Float) -> Unit
+    ): List<Uri> = withContext(Dispatchers.IO) {
+        val (destVolume, destRelPath) = resolveMediaStoreVolume(newPath)
+        val copies = mutableListOf<Uri>()
+        mediaList.forEachIndexed { index, media ->
+            val copiedUri = copyMediaTo(media, destVolume, destRelPath)
+            if (copiedUri == null) {
+                // Never leave half a move behind: the originals are still untouched at this
+                // point, so drop the copies we own and report the failure.
+                discardMediaCopies(copies)
+                return@withContext emptyList()
+            }
+            copies += copiedUri
+            onProgress((index + 1).toFloat() / mediaList.size)
+        }
+        copies
+    }
+
+    override suspend fun discardMediaCopies(uris: List<Uri>) = withContext(Dispatchers.IO) {
+        uris.forEach {
+            runCatching { contentResolver.delete(it, null, null) }
+                .onFailure { error -> printWarning("Failed to discard copy: ${error.message}") }
         }
     }
 

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/domain/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/domain/repository/MediaRepository.kt
@@ -143,6 +143,20 @@ interface MediaRepository {
         newPath: String
     ): Boolean
 
+    /**
+     * Copies [mediaList] into [newPath] and returns the uris of the copies, or an empty list if
+     * any of them failed - in which case nothing is left behind. Used to move media the app
+     * cannot rename, the originals being removed afterwards through a delete request.
+     */
+    suspend fun <T: Media> copyMediaForMove(
+        mediaList: List<T>,
+        newPath: String,
+        onProgress: suspend (Float) -> Unit = {}
+    ): List<Uri>
+
+    /** Removes copies made by [copyMediaForMove], for instance when the move is cancelled. */
+    suspend fun discardMediaCopies(uris: List<Uri>)
+
     suspend fun probeMetadataSanitization(media: Media): SanitizationCapability
 
     suspend fun sanitizeMediaMetadata(

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/CopyMediaSheet.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/CopyMediaSheet.kt
@@ -64,8 +64,6 @@ import com.dot.gallery.core.presentation.components.SecurityInfoSheet
 import com.dot.gallery.feature_node.domain.model.Album
 import com.dot.gallery.feature_node.domain.model.AlbumState
 import com.dot.gallery.feature_node.domain.model.Media
-import com.dot.gallery.feature_node.domain.util.isCloud
-import com.dot.gallery.feature_node.domain.util.mediaStoreVolumeName
 import com.dot.gallery.feature_node.presentation.albums.components.AlbumComponent
 import com.dot.gallery.feature_node.presentation.mediaview.rememberedDerivedState
 import com.dot.gallery.feature_node.presentation.util.AppBottomSheetState
@@ -101,16 +99,11 @@ fun <T: Media> CopyMediaSheet(
     var pendingLockedAlbumPath by remember { mutableStateOf<String?>(null) }
     var searchQuery by remember { mutableStateOf("") }
     val mutex = Mutex()
-    val sources = mediaList.filter { !it.isCloud }.map {
-        AlbumDestinationSource(it.mediaStoreVolumeName, it.relativePath)
-    }
 
     fun Album.isCopyDestinationEnabled(): Boolean = absolutePath.isNotBlank() &&
-        isAlbumDestinationEnabled(
+        isAlbumCopyDestinationEnabled(
             hasFullMediaAccess = hasFullMediaAccess,
-            albumVolume = volume,
             albumRelativePath = relativePath,
-            sources = sources,
             isCloudAlbum = uri.scheme == "cloud" || relativePath.startsWith("cloud/"),
         )
 

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
@@ -461,6 +461,21 @@ internal fun isAlbumDestinationEnabled(
     }
 }
 
+/**
+ * A copy only reads the source through MediaStore and inserts a brand new file at the
+ * destination, so restricted sources (another app's `Android/media/<package>` folder, or a
+ * different storage volume) do not need write access. Only the destination has to be writable.
+ */
+internal fun isAlbumCopyDestinationEnabled(
+    hasFullMediaAccess: Boolean,
+    albumRelativePath: String,
+    isCloudAlbum: Boolean = false,
+): Boolean {
+    if (isCloudAlbum) return false
+    if (hasFullMediaAccess) return true
+    return !albumRelativePath.isAndroidMediaPath()
+}
+
 internal fun isAlbumMoveDestinationEnabled(
     hasFullMediaAccess: Boolean,
     albumVolume: String,

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
@@ -1,6 +1,7 @@
 package com.dot.gallery.feature_node.presentation.exif
 
 import android.media.MediaScannerConnection
+import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
@@ -59,6 +60,7 @@ import com.dot.gallery.feature_node.domain.model.Album
 import com.dot.gallery.feature_node.domain.model.AlbumGroupWithAlbums
 import com.dot.gallery.feature_node.domain.model.AlbumState
 import com.dot.gallery.feature_node.domain.model.Media
+import com.dot.gallery.feature_node.domain.repository.MediaMutationResult
 import com.dot.gallery.feature_node.domain.util.isCloud
 import com.dot.gallery.feature_node.domain.util.mediaStoreVolumeName
 import com.dot.gallery.feature_node.domain.util.resolveMediaStoreVolume
@@ -75,6 +77,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -158,6 +161,57 @@ fun <T: Media> MoveMediaSheet(
 
     val request = rememberActivityResult { doMove() }
 
+    var pendingCopies by remember(mediaList) { mutableStateOf<List<Uri>>(emptyList()) }
+
+    val finishMove: () -> Unit = {
+        scope.launch {
+            context.contentResolver.notifyChange(
+                MediaStore.Files.getContentUri("external"), null
+            )
+            pendingCopies = emptyList()
+            sheetState.hide()
+            onFinish()
+        }
+    }
+
+    val deleteRequest = rememberActivityResult(
+        onResultCanceled = {
+            // The originals stay where they are, so drop the copies: a cancelled move must
+            // not leave a duplicate behind.
+            scope.launch {
+                handler.discardMediaCopies(pendingCopies)
+                pendingCopies = emptyList()
+                progress = 0f
+                sheetState.hide()
+            }
+        },
+        onResultOk = finishMove
+    )
+
+    /**
+     * Media stored in another app's `Android/media/<package>` folder cannot be renamed into an
+     * album. Copy the selection to the destination first, then let the system ask the user to
+     * confirm the removal of the originals - a single dialog for the whole batch.
+     */
+    fun startRestrictedMove(albumPath: String, localMedia: List<T>) {
+        scope.launch {
+            val copies = handler.copyMediaForMove(localMedia, albumPath) { copyProgress ->
+                withContext(Dispatchers.Main) { progress = copyProgress }
+            }
+            if (copies.isEmpty()) {
+                progress = 0f
+                toastError.show()
+                delay(1000)
+                sheetState.hide()
+                return@launch
+            }
+            pendingCopies = copies
+            if (handler.deleteMedia(deleteRequest, localMedia) == MediaMutationResult.COMPLETED) {
+                finishMove()
+            }
+        }
+    }
+
     fun startMove(albumPath: String) {
         val cloudMedia = mediaList.filter { it.isCloud }
         val localMedia = localMediaForDestination(albumPath)
@@ -167,12 +221,16 @@ fun <T: Media> MoveMediaSheet(
         }
         // For local media: use the standard write-request move flow
         if (localMedia.isNotEmpty()) {
-            scope.launch(Dispatchers.Main) {
-                newPath = albumPath
-                request.launchWriteRequest(
-                    localMedia.writeRequest(context.contentResolver),
-                    doMove
-                )
+            if (restrictedMoveSources(hasFullMediaAccess, localMedia).isNotEmpty()) {
+                startRestrictedMove(albumPath, localMedia)
+            } else {
+                scope.launch(Dispatchers.Main) {
+                    newPath = albumPath
+                    request.launchWriteRequest(
+                        localMedia.writeRequest(context.contentResolver),
+                        doMove
+                    )
+                }
             }
         } else {
             // All cloud — just finish after enqueue
@@ -424,13 +482,9 @@ fun <T: Media> MoveMediaSheet(
     AddAlbumSheet(
         sheetState = newAlbumSheetState,
         onFinish = { newAlbum ->
-            scope.launch(Dispatchers.Main) {
-                newPath = if (hasFullMediaAccess) newAlbum else "Pictures/$newAlbum"
-                request.launchWriteRequest(
-                    mediaList.writeRequest(context.contentResolver),
-                    doMove
-                )
-            }
+            // Same routing as an existing album so restricted sources reach the copy +
+            // delete-request path here too.
+            startMove(if (hasFullMediaAccess) newAlbum else "Pictures/$newAlbum")
         },
         onCancel = {
             if (newAlbumSheetState.isVisible) {
@@ -447,20 +501,6 @@ internal data class AlbumDestinationSource(
     val relativePath: String,
 )
 
-internal fun isAlbumDestinationEnabled(
-    hasFullMediaAccess: Boolean,
-    albumVolume: String,
-    albumRelativePath: String,
-    sources: List<AlbumDestinationSource>,
-    isCloudAlbum: Boolean = false,
-): Boolean {
-    if (isCloudAlbum) return false
-    if (hasFullMediaAccess) return true
-    return !albumRelativePath.isAndroidMediaPath() && sources.all {
-        it.volume == albumVolume && !it.relativePath.isAndroidMediaPath()
-    }
-}
-
 /**
  * A copy only reads the source through MediaStore and inserts a brand new file at the
  * destination, so restricted sources (another app's `Android/media/<package>` folder, or a
@@ -476,23 +516,36 @@ internal fun isAlbumCopyDestinationEnabled(
     return !albumRelativePath.isAndroidMediaPath()
 }
 
+/**
+ * A move needs the original gone once the destination holds it. Sources inside another app's
+ * `Android/media/<package>` folder cannot be renamed, so they take the copy + delete-request
+ * path instead: the destination rules are the same as for a copy, plus a source that actually
+ * differs from the destination folder.
+ */
 internal fun isAlbumMoveDestinationEnabled(
     hasFullMediaAccess: Boolean,
     albumVolume: String,
     albumRelativePath: String,
     sources: List<AlbumDestinationSource>,
     isCloudAlbum: Boolean = false,
-): Boolean = isAlbumDestinationEnabled(
-    hasFullMediaAccess = hasFullMediaAccess,
-    albumVolume = albumVolume,
-    albumRelativePath = albumRelativePath,
-    sources = sources,
-    isCloudAlbum = isCloudAlbum,
-) && (sources.isEmpty() || sources.any {
-    it.volume != albumVolume || it.relativePath.trim('/') != albumRelativePath.trim('/')
-})
+): Boolean {
+    if (!isAlbumCopyDestinationEnabled(hasFullMediaAccess, albumRelativePath, isCloudAlbum)) {
+        return false
+    }
+    if (!hasFullMediaAccess && sources.any { it.volume != albumVolume }) return false
+    return sources.isEmpty() || sources.any {
+        it.volume != albumVolume || it.relativePath.trim('/') != albumRelativePath.trim('/')
+    }
+}
 
-private fun String.isAndroidMediaPath(): Boolean = trim('/').let {
+/** Sources that only a copy + delete request can take out of their folder. */
+internal fun <T : Media> restrictedMoveSources(
+    hasFullMediaAccess: Boolean,
+    mediaList: List<T>,
+): List<T> = if (hasFullMediaAccess) emptyList()
+    else mediaList.filter { it.relativePath.isAndroidMediaPath() }
+
+internal fun String.isAndroidMediaPath(): Boolean = trim('/').let {
     it == "Android/media" || it.startsWith("Android/media/")
 }
 

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/exif/MoveMediaSheet.kt
@@ -206,8 +206,18 @@ fun <T: Media> MoveMediaSheet(
                 return@launch
             }
             pendingCopies = copies
-            if (handler.deleteMedia(deleteRequest, localMedia) == MediaMutationResult.COMPLETED) {
-                finishMove()
+            when (handler.deleteMedia(deleteRequest, localMedia)) {
+                // The dialog drives the rest through deleteRequest.
+                MediaMutationResult.REQUEST_LAUNCHED -> Unit
+                MediaMutationResult.COMPLETED -> finishMove()
+                MediaMutationResult.FAILED -> {
+                    handler.discardMediaCopies(copies)
+                    pendingCopies = emptyList()
+                    progress = 0f
+                    toastError.show()
+                    delay(1000)
+                    sheetState.hide()
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/util/MockedProviders.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/util/MockedProviders.kt
@@ -141,6 +141,14 @@ class MockedMediaHandler: MediaHandler {
         newPath: String
     ): Boolean = false
 
+    override suspend fun <T : Media> copyMediaForMove(
+        mediaList: List<T>,
+        newPath: String,
+        onProgress: suspend (Float) -> Unit
+    ): List<Uri> = emptyList()
+
+    override suspend fun discardMediaCopies(uris: List<Uri>) = Unit
+
     override suspend fun probeMetadataSanitization(
         media: Media
     ): SanitizationCapability = SanitizationCapability(MediaContainerFormat.UNKNOWN, emptySet())

--- a/app/src/test/java/com/dot/gallery/AlbumDestinationPolicyTest.kt
+++ b/app/src/test/java/com/dot/gallery/AlbumDestinationPolicyTest.kt
@@ -94,6 +94,56 @@ class AlbumDestinationPolicyTest {
     }
 
     @Test
+    fun copyFromRestrictedSourceStaysEnabledForWritableAlbum() {
+        // Copying a WhatsApp image (Android/media/com.whatsapp/...) into an existing album only
+        // reads the source and inserts a new file at the destination.
+        val restrictedSource = listOf(
+            AlbumDestinationSource(
+                "external_primary",
+                "Android/media/com.whatsapp/WhatsApp/Media/WhatsApp Images/",
+            ),
+        )
+
+        assertTrue(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = false,
+                albumRelativePath = "Pictures/Target/",
+            )
+        )
+        assertFalse(
+            isAlbumMoveDestinationEnabled(
+                false,
+                "external_primary",
+                "Pictures/Target/",
+                restrictedSource,
+            )
+        )
+    }
+
+    @Test
+    fun copyToRestrictedOrCloudAlbumStaysDisabled() {
+        assertFalse(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = false,
+                albumRelativePath = "Android/media/example.app/Pictures/",
+            )
+        )
+        assertFalse(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = true,
+                albumRelativePath = "cloud/IMMICH/Album",
+                isCloudAlbum = true,
+            )
+        )
+        assertTrue(
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = true,
+                albumRelativePath = "Android/media/example.app/Pictures/",
+            )
+        )
+    }
+
+    @Test
     fun moveDisablesExactSourceFolderButAllowsDifferentSameNamedFolder() {
         val sources = listOf(AlbumDestinationSource("external_primary", "DCIM/Camera/"))
 

--- a/app/src/test/java/com/dot/gallery/AlbumDestinationPolicyTest.kt
+++ b/app/src/test/java/com/dot/gallery/AlbumDestinationPolicyTest.kt
@@ -16,7 +16,7 @@ class AlbumDestinationPolicyTest {
     @Test
     fun matchingMediaStoreVolumesEnableExistingAlbum() {
         assertTrue(
-            isAlbumDestinationEnabled(
+            isAlbumMoveDestinationEnabled(
                 hasFullMediaAccess = false,
                 albumVolume = "external_primary",
                 albumRelativePath = "Pictures/Target/",
@@ -31,7 +31,7 @@ class AlbumDestinationPolicyTest {
     @Test
     fun anyDifferentMediaStoreVolumeDisablesBatchWithoutFullAccess() {
         assertFalse(
-            isAlbumDestinationEnabled(
+            isAlbumMoveDestinationEnabled(
                 hasFullMediaAccess = false,
                 albumVolume = "external_primary",
                 albumRelativePath = "Pictures/Target/",
@@ -44,14 +44,11 @@ class AlbumDestinationPolicyTest {
     }
 
     @Test
-    fun androidMediaSourceOrDestinationIsDisabledWithoutFullAccess() {
+    fun androidMediaDestinationIsDisabledWithoutFullAccess() {
         val regularSource = listOf(AlbumDestinationSource("external_primary", "DCIM/Camera/"))
-        val restrictedSource = listOf(
-            AlbumDestinationSource("external_primary", "Android/media/example.app/Pictures/"),
-        )
 
         assertFalse(
-            isAlbumDestinationEnabled(
+            isAlbumMoveDestinationEnabled(
                 false,
                 "external_primary",
                 "Android/media/example.app/Pictures/",
@@ -59,11 +56,9 @@ class AlbumDestinationPolicyTest {
             )
         )
         assertFalse(
-            isAlbumDestinationEnabled(
-                false,
-                "external_primary",
-                "Pictures/Target/",
-                restrictedSource,
+            isAlbumCopyDestinationEnabled(
+                hasFullMediaAccess = false,
+                albumRelativePath = "Android/media/example.app/Pictures/",
             )
         )
     }
@@ -72,9 +67,9 @@ class AlbumDestinationPolicyTest {
     fun fullAccessAllowsCrossVolumeButNeverCloudDestination() {
         val sources = listOf(AlbumDestinationSource("external_primary", "DCIM/Camera/"))
 
-        assertTrue(isAlbumDestinationEnabled(true, "71f8-2c0a", "Pictures/Target/", sources))
+        assertTrue(isAlbumMoveDestinationEnabled(true, "71f8-2c0a", "Pictures/Target/", sources))
         assertFalse(
-            isAlbumDestinationEnabled(
+            isAlbumMoveDestinationEnabled(
                 true,
                 "IMMICH",
                 "cloud/IMMICH/Album",
@@ -83,7 +78,7 @@ class AlbumDestinationPolicyTest {
             )
         )
         assertTrue(
-            isAlbumDestinationEnabled(
+            isAlbumMoveDestinationEnabled(
                 true,
                 "external_primary",
                 "cloud/LocalAlbum/",
@@ -94,9 +89,9 @@ class AlbumDestinationPolicyTest {
     }
 
     @Test
-    fun copyFromRestrictedSourceStaysEnabledForWritableAlbum() {
-        // Copying a WhatsApp image (Android/media/com.whatsapp/...) into an existing album only
-        // reads the source and inserts a new file at the destination.
+    fun restrictedSourceStaysEnabledForWritableAlbum() {
+        // A WhatsApp image (Android/media/com.whatsapp/...) can be copied into an existing album,
+        // and moved there through the copy + delete-request path.
         val restrictedSource = listOf(
             AlbumDestinationSource(
                 "external_primary",
@@ -110,7 +105,7 @@ class AlbumDestinationPolicyTest {
                 albumRelativePath = "Pictures/Target/",
             )
         )
-        assertFalse(
+        assertTrue(
             isAlbumMoveDestinationEnabled(
                 false,
                 "external_primary",
@@ -176,7 +171,7 @@ class AlbumDestinationPolicyTest {
     @Test
     fun cloudOnlySelectionCanTargetWritableLocalAlbum() {
         assertTrue(
-            isAlbumDestinationEnabled(
+            isAlbumMoveDestinationEnabled(
                 false,
                 "external_primary",
                 "Pictures/Target/",


### PR DESCRIPTION
Follow-up to #1145 (and stacked on it - the copy fix is the first of the four commits here, so this PR shows it until #1145 is merged). Related to #1144.

### 1. Moving media out of a restricted folder

An image received through WhatsApp lives in `Android/media/com.whatsapp/…`. It can be copied into an album, but a move was disabled for every destination, because a move renames the file and MediaProvider refuses that without `MANAGE_EXTERNAL_STORAGE`/`MANAGE_MEDIA`:

```
W GalleryInfo: Changing ownership from /storage/emulated/0/Android/media/com.whatsapp/…/VID-xxxxxxxx-WAxxxx.mp4
               to /storage/emulated/0/Pictures/<album>/… not allowed
```

Such a selection now takes a **copy + `MediaStore.createDeleteRequest()`** path: the files are copied to the destination, then the system asks the user to confirm the removal of the originals.

- A failed copy stops before anything is deleted, and the partial copies are discarded.
- Declining the deletion discards the copies too, so a cancelled move leaves nothing behind.
- `deleteMedia()` can also return `FAILED` without launching anything - a selection holding Files-collection items (a JXL/AVIF the system did not index as an image) without full access, or a uri `createDeleteRequest` rejects. That case discards the copies and reports the failure rather than leaving them in the destination unannounced.
- Leaving the sheet mid-copy cancels the scope; the copies made so far are rolled back before giving up.
- The picker policy is split accordingly: `isAlbumCopyDestinationEnabled` (destination only) and `isAlbumMoveDestinationEnabled` (same, plus a source that actually differs from the destination). The old `isAlbumDestinationEnabled` is gone, its cases live on in the two.
- Creating a new album from the move sheet now goes through the same routing, which fixes the error it raised for these sources.

A batch is handled as one unit: a single system dialog for the whole selection. When at least one item is restricted, the whole local selection takes the copy + delete path, including items that could have been renamed - they come back with a new MediaStore id. Splitting the batch in two would avoid that, at the cost of two consecutive dialogs; happy to change it if you prefer that trade-off.

### 2. Copies no longer land at today's date

Independent of the above, and worth cherry-picking on its own: anything copied — or moved through the new path — arrived in its album stamped with the time of the copy, jumping to the top of the timeline.

MediaProvider ignores `DATE_MODIFIED` and `DATE_TAKEN` written by an app and recomputes them from the file, so passing them through `ContentValues` does nothing. Measured on device, with a throwaway instrumented probe:

```
insert + publish with the dates          -> date_modified = now       ✗
extra update once published              -> date_modified = now       ✗
setLastModified alone                    -> date_modified = now       ✗
setLastModified + MediaScannerConnection -> date_modified = source    ✓
```

`restoreMediaTimestamp()` therefore sets the timestamp on the file and rescans it; both copy paths call it once the copy is published. This is most visible on WhatsApp media, where `DATE_TAKEN` is null (the EXIF is stripped) and the ordering falls back to `DATE_MODIFIED` alone.

### Tests

```
./gradlew :app:testArm64-v8aNoMLDebugUnitTest                                    # incl. AlbumDestinationPolicyTest
./gradlew :app:connectedArm64-v8aNoMLDebugAndroidTest \
    -Pandroid.testInstrumentationRunnerArguments.class=com.dot.gallery.core.util.ext.MediaTimestampTest
./gradlew :app:assembleArm64-v8aNoMLDebug
```

`MediaTimestampTest` is new: it checks that a freshly written file comes back with the time of the write, and that `restoreMediaTimestamp` brings it back to the source timestamp.

### Device verification

OnePlus 5T, LineageOS 22 (Android 15), without "All files access" or "Media management":

- moving a WhatsApp image into an existing album: works;
- into a new album: works;
- declining the system deletion dialog: no copy left behind;
- copied and moved media keep their original date in the timeline.

### Note

The copy progress in the move sheet is per file, so a single large video shows no intermediate progress. Say the word if you would rather have byte-level progress there, like `MediaCopyWorker` does.
