### PR TITLE
fix: composite hardware markup overlays on software canvases

### DIFF
--- a/app/src/androidTest/java/com/dot/gallery/MarkupAdjustmentTest.kt
+++ b/app/src/androidTest/java/com/dot/gallery/MarkupAdjustmentTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.dot.gallery.feature_node.presentation.edit.adjustments.Markup
 import com.dot.gallery.feature_node.presentation.edit.bake.EditReplay
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -71,6 +72,41 @@ class MarkupAdjustmentTest {
             overlay.recycle()
             tile.recycle()
             result.recycle()
+        }
+    }
+
+    @Test
+    fun hardwareOverlayStillCompositesOntoSoftwareBases() {
+        // GraphicsLayer.toImageBitmap() returns a HARDWARE bitmap on some devices; a software
+        // Canvas silently ignores those, which used to make the markup a no-op (#1078).
+        val softwareOverlay = solidBitmap(4, 4, Color.TRANSPARENT).apply {
+            for (y in 0 until height) {
+                for (x in 0 until width / 2) {
+                    setPixel(x, y, Color.RED)
+                }
+            }
+        }
+        val overlay = softwareOverlay.copy(Bitmap.Config.HARDWARE, false)
+        val base = solidBitmap(4, 4, Color.GREEN)
+        val tile = solidBitmap(2, 4, Color.GREEN)
+        val adjustment = Markup(overlay)
+        val result = adjustment.apply(base)
+        val tileResult = adjustment.applyTile(tile, fullWidth = 4, fullHeight = 4, tileX = 0, tileY = 0)
+
+        try {
+            assertEquals(Bitmap.Config.HARDWARE, overlay.config)
+            assertFalse(result.sameAs(base))
+            assertEquals(Color.RED, result.getPixel(0, 0))
+            assertEquals(Color.GREEN, result.getPixel(3, 3))
+            assertEquals(Color.RED, tileResult.getPixel(0, 0))
+            assertEquals(Color.RED, tileResult.getPixel(1, 3))
+        } finally {
+            softwareOverlay.recycle()
+            overlay.recycle()
+            base.recycle()
+            tile.recycle()
+            result.recycle()
+            tileResult.recycle()
         }
     }
 

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/edit/adjustments/Markup.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/edit/adjustments/Markup.kt
@@ -17,6 +17,20 @@ import com.dot.gallery.feature_node.domain.model.editor.TileableAdjustment
  */
 data class Markup(val overlay: Bitmap): TileableAdjustment {
 
+    /**
+     * [overlay] is captured with `GraphicsLayer.toImageBitmap()`, which hands back a
+     * [Bitmap.Config.HARDWARE] bitmap on some devices/renderers. A software [Canvas] silently draws
+     * nothing from a hardware bitmap, so the composite came out identical to the base and the
+     * editor's no-op guard dropped the whole markup (#1078). Composite from a software copy instead.
+     */
+    private val drawableOverlay: Bitmap by lazy {
+        if (overlay.config == Bitmap.Config.HARDWARE) {
+            overlay.copy(Bitmap.Config.ARGB_8888, false)
+        } else {
+            overlay
+        }
+    }
+
     override fun apply(bitmap: Bitmap): Bitmap {
         val config = bitmap.config?.takeUnless { it == Bitmap.Config.HARDWARE }
             ?: Bitmap.Config.ARGB_8888
@@ -27,7 +41,7 @@ data class Markup(val overlay: Bitmap): TileableAdjustment {
                 bitmap.height / overlay.height.toFloat()
             )
         }
-        Canvas(result).drawBitmap(overlay, matrix, Paint(Paint.FILTER_BITMAP_FLAG))
+        Canvas(result).drawBitmap(drawableOverlay, matrix, Paint(Paint.FILTER_BITMAP_FLAG))
         return result
     }
 
@@ -50,7 +64,7 @@ data class Markup(val overlay: Bitmap): TileableAdjustment {
             )
             postTranslate(-tileX.toFloat(), -tileY.toFloat())
         }
-        canvas.drawBitmap(overlay, matrix, Paint(Paint.FILTER_BITMAP_FLAG))
+        canvas.drawBitmap(drawableOverlay, matrix, Paint(Paint.FILTER_BITMAP_FLAG))
         return result
     }
 


### PR DESCRIPTION
## Summary

Every Markup tool edit (blur, mosaic, pen, highlighter, text) was discarded the moment it was applied on devices where `GraphicsLayer.toImageBitmap()` returns a `HARDWARE` bitmap. `Markup.apply()` drew that overlay onto a software `Canvas`, which silently paints nothing from a hardware bitmap, so the composite was pixel-identical to the base and the editor's no-op guard (`applyAdjustmentAndWait`, #957/#961) dropped the whole markup without any log line.

This PR composites from a lazily converted `ARGB_8888` copy of the overlay in both `Markup.apply()` and `Markup.applyTile()`, so the interactive proxy and the tiled full-resolution bake both see the strokes.

Fixes #1177 (follow-up to #1078, whose fix was verified on a device that yields a software overlay).

## Verification

- Reproduced on a OnePlus 5T (LineageOS 22 / Android 15) with ReFra 5.1.3 from F-Droid: an instrumented debug build logged `image=1080x810/HARDWARE sampledOpaque=517` for the captured overlay, then `noOp=true` in `applyAdjustmentAndWait`.
- With the fix, on the same device: blur strokes survive ✓, undo works, "Save copy" is enabled, and the saved JPEG contains the blur (mean pixel delta ≈ 12–14 in the painted regions vs ≈ 1 JPEG noise elsewhere).
- `./gradlew :app:connectedArm64-v8aNoMLDebugAndroidTest` filtered to `MarkupAdjustmentTest`: 3 tests passed, including the new `hardwareOverlayStillCompositesOntoSoftwareBases`.
- `./gradlew :app:assembleArm64-v8aNoMLDebug`, `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrMwjU3G5L9x3bbiWJtA55
